### PR TITLE
[main] 행사 api(/event) 리팩토링

### DIFF
--- a/src/common/filters/http-exception.filter.ts
+++ b/src/common/filters/http-exception.filter.ts
@@ -1,0 +1,17 @@
+import { ExceptionFilter, Catch, ArgumentsHost, HttpException } from '@nestjs/common'
+import { Response } from 'express'
+
+@Catch(HttpException)
+export class HttpExceptionFilter implements ExceptionFilter {
+  catch(exception: HttpException, host: ArgumentsHost) {
+    const ctx = host.switchToHttp()
+    const response = ctx.getResponse<Response>()
+    const status = exception.getStatus()
+
+    response.status(status).json({
+      statusCode: status,
+      message: exception.message,
+      timestamp: Date.now()
+    })
+  }
+}

--- a/src/events/events.controller.ts
+++ b/src/events/events.controller.ts
@@ -1,53 +1,34 @@
-import { Controller, Get, HttpCode, HttpException, HttpStatus, Param, Query } from '@nestjs/common'
+import { Controller, Get, HttpCode, HttpStatus, Param, Query, UseFilters } from '@nestjs/common'
 import { EventsService } from '@/events/events.service'
+import { HttpExceptionFilter } from '@/common/filters/http-exception.filter'
 
 @Controller('event')
+@UseFilters(HttpExceptionFilter)
 export class EventsController {
   constructor(private readonly eventsService: EventsService) {}
 
   @Get('/list')
   @HttpCode(HttpStatus.OK)
-  async getEventList(@Query('limit') limit: string, @Query('offset') offset: string) {
-    try {
-      const result = await this.eventsService.getEventList(limit, offset)
-      return result
-    } catch (err: unknown) {
-      if (!(err instanceof HttpException)) {
-        throw new HttpException({ message: 'Unknown Error', error: err }, HttpStatus.INTERNAL_SERVER_ERROR)
-      }
-      throw err
-    }
+  getEventList(@Query('limit') limit: string, @Query('offset') offset: string) {
+    const result = this.eventsService.getEventList(limit, offset)
+    return result
   }
 
   @Get('/list/:categorySeq')
   @HttpCode(HttpStatus.OK)
-  async getEventListByCategory(
+  getEventListByCategory(
     @Param('categorySeq') categorySeq: string,
     @Query('limit') limit: string,
     @Query('offset') offset: string
   ) {
-    try {
-      const result = await this.eventsService.getEventsByCategory(categorySeq, limit, offset)
-      return result
-    } catch (err: unknown) {
-      if (!(err instanceof HttpException)) {
-        throw new HttpException({ message: 'Unknown Error', error: err }, HttpStatus.INTERNAL_SERVER_ERROR)
-      }
-      throw err
-    }
+    const result = this.eventsService.getEventsByCategory(categorySeq, limit, offset)
+    return result
   }
 
   @Get('/:eventId')
   @HttpCode(HttpStatus.OK)
-  async getEventDetail(@Param('eventId') eventId: string) {
-    try {
-      const result = await this.eventsService.getEventDetail(eventId)
-      return result
-    } catch (err: unknown) {
-      if (!(err instanceof HttpException)) {
-        throw new HttpException({ message: 'Unknown Error', error: err }, HttpStatus.INTERNAL_SERVER_ERROR)
-      }
-      throw err
-    }
+  getEventDetail(@Param('eventId') eventId: string) {
+    const result = this.eventsService.getEventDetail(eventId)
+    return result
   }
 }

--- a/src/events/events.dto.ts
+++ b/src/events/events.dto.ts
@@ -1,31 +1,4 @@
-import type { Model, ObjectId } from 'mongoose'
-
-export interface IEventData {
-  _id: ObjectId
-  event_id: number
-  category_seq: number
-  gu_seq: number | null
-  event_name: string
-  period: string
-  place: string
-  org_name: string
-  use_target: string
-  ticket_price: string | null
-  player: string | null
-  describe: string | null
-  etc_desc: string | null
-  homepage_link: string
-  main_img: string
-  reg_date: Date
-  is_public: boolean
-  start_date: Date
-  end_date: Date
-  theme: string | null
-  latitude: number
-  longitude: number
-  is_free: boolean
-  detail_url: string
-}
+import type { IEventData } from '@/events/types/events.type'
 
 export class EventDTO {
   eventId: number
@@ -95,5 +68,3 @@ export class EventDetailResponseDTO {
     this.data = data
   }
 }
-
-export type EventsModel = Model<IEventData>

--- a/src/events/types/events.type.ts
+++ b/src/events/types/events.type.ts
@@ -1,0 +1,30 @@
+import type { Model, ObjectId } from 'mongoose'
+
+export interface IEventData {
+  _id: ObjectId
+  event_id: number
+  category_seq: number
+  gu_seq: number | null
+  event_name: string
+  period: string
+  place: string
+  org_name: string
+  use_target: string
+  ticket_price: string | null
+  player: string | null
+  describe: string | null
+  etc_desc: string | null
+  homepage_link: string
+  main_img: string
+  reg_date: Date
+  is_public: boolean
+  start_date: Date
+  end_date: Date
+  theme: string | null
+  latitude: number
+  longitude: number
+  is_free: boolean
+  detail_url: string
+}
+
+export type EventsModel = Model<IEventData>


### PR DESCRIPTION
### 1. 행사 api(/event) 리팩토링
1. 반영 사항
    - [x] error 핸들링에 대한 리팩토링
      - filter 클래스 제작, UseFilter 데코레이터 적용
      - catch되는 에러는 모두 service 단에서 핸들링 하는 것을 중점으로 리팩토링
      - 기존 controller는 service코드를 실행시키기만 하는 형태로 역할 축소
    - [x] events데이터 타입 dto에서 분리
      - events 폴더 하위에 types폴더로 분리 관리