### PR TITLE
[main] status 400이상 호출 정보 db로깅 추가

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -19,7 +19,7 @@ import { HttpExceptionFilter } from './common/filters/http-exception.filter'
     MongooseModule.forRootAsync({
       imports: [ConfigModule],
       useFactory: (env: ConfigService) => ({
-        uri: env.get<string>('MONGO_URI_LOCAL')
+        uri: env.get<string>('MONGO_URI_PRODUCTION')
       }),
       inject: [ConfigService]
     }),

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common'
+import { MiddlewareConsumer, Module, RequestMethod } from '@nestjs/common'
 import { MongooseModule } from '@nestjs/mongoose'
 import { ConfigModule, ConfigService } from '@nestjs/config'
 import { ScheduleModule } from '@nestjs/schedule'
@@ -6,6 +6,10 @@ import { AppController } from '@/app.controller'
 import { AppService } from '@/app.service'
 import { PushModule } from '@/push/push.module'
 import { EventsModule } from '@/events/events.module'
+import { Log, LogSchema } from '@/schema/logs.schema'
+import { LoggingMiddleware } from '@/middleware/loggin.middleware'
+import { APP_FILTER } from '@nestjs/core'
+import { HttpExceptionFilter } from './common/filters/http-exception.filter'
 
 @Module({
   imports: [
@@ -15,15 +19,20 @@ import { EventsModule } from '@/events/events.module'
     MongooseModule.forRootAsync({
       imports: [ConfigModule],
       useFactory: (env: ConfigService) => ({
-        uri: env.get<string>('MONGO_URI_PRODUCTION')
+        uri: env.get<string>('MONGO_URI_LOCAL')
       }),
       inject: [ConfigService]
     }),
+    MongooseModule.forFeature([{ name: Log.name, schema: LogSchema }]),
     ScheduleModule.forRoot(),
     PushModule,
     EventsModule
   ],
   controllers: [AppController],
-  providers: [AppService]
+  providers: [AppService, { provide: APP_FILTER, useClass: HttpExceptionFilter }]
 })
-export class AppModule {}
+export class AppModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(LoggingMiddleware).forRoutes({ path: '*', method: RequestMethod.ALL })
+  }
+}

--- a/src/common/filters/http-exception.filter.ts
+++ b/src/common/filters/http-exception.filter.ts
@@ -1,12 +1,36 @@
-import { ExceptionFilter, Catch, ArgumentsHost, HttpException } from '@nestjs/common'
-import { Response } from 'express'
+import { ExceptionFilter, Catch, ArgumentsHost, HttpException, HttpStatus } from '@nestjs/common'
+import { InjectModel } from '@nestjs/mongoose'
+import mongoose from 'mongoose'
+import { Log } from '@/schema/logs.schema'
+import type { Response } from 'express'
+import type { LogModel } from '@/schema/logs.schema'
 
 @Catch(HttpException)
 export class HttpExceptionFilter implements ExceptionFilter {
-  catch(exception: HttpException, host: ArgumentsHost) {
+  constructor(@InjectModel(Log.name) private customLog: LogModel) {}
+
+  async catch(exception: HttpException, host: ArgumentsHost) {
     const ctx = host.switchToHttp()
     const response = ctx.getResponse<Response>()
+    const request = ctx.getRequest()
     const status = exception.getStatus()
+
+    const logFormat = {
+      request_id: new mongoose.Types.ObjectId(),
+      level: status >= HttpStatus.INTERNAL_SERVER_ERROR ? 'error' : status >= HttpStatus.BAD_REQUEST && 'warn',
+      error_name: exception.name,
+      method: request.method,
+      status_code: status,
+      message: exception.message,
+      original_url: request.originalUrl,
+      hostname: request.hostname,
+      headers: request.headers,
+      timestamp: Date.now()
+    }
+
+    const logEntry = new this.customLog(logFormat)
+
+    await logEntry.save()
 
     response.status(status).json({
       statusCode: status,

--- a/src/events/events.module.ts
+++ b/src/events/events.module.ts
@@ -3,6 +3,7 @@ import { MongooseModule } from '@nestjs/mongoose'
 import { EventsSchema, Events } from '@/schema/events.schema'
 import { EventsController } from '@/events/events.controller'
 import { EventsService } from '@/events/events.service'
+import { Log, LogSchema } from '@/schema/logs.schema'
 
 @Module({
   imports: [
@@ -10,6 +11,10 @@ import { EventsService } from '@/events/events.service'
       {
         name: Events.name,
         schema: EventsSchema
+      },
+      {
+        name: Log.name,
+        schema: LogSchema
       }
     ])
   ],

--- a/src/middleware/loggin.middleware.ts
+++ b/src/middleware/loggin.middleware.ts
@@ -1,0 +1,34 @@
+import { Injectable, NestMiddleware, Logger } from '@nestjs/common'
+import { InjectModel } from '@nestjs/mongoose'
+import { Request, Response, NextFunction } from 'express'
+import { Log } from '@/schema/logs.schema'
+import type { LogModel } from '@/schema/logs.schema'
+
+@Injectable()
+export class LoggingMiddleware implements NestMiddleware {
+  constructor(@InjectModel(Log.name) readonly customLog: LogModel) {}
+
+  private readonly logger = new Logger(LoggingMiddleware.name)
+
+  use(req: Request, res: Response, next: NextFunction) {
+    const { method, ip, originalUrl, hostname } = req
+    const startTime = Date.now()
+
+    res.on('finish', async () => {
+      const { statusCode, statusMessage } = res
+      const responseTime = Date.now() - startTime
+
+      const logMessage = `${method} | ${statusCode} | ${statusMessage} | ${originalUrl} | ${ip} | ${hostname} | ${responseTime}ms`
+
+      if (statusCode >= 500) {
+        this.logger.error(logMessage)
+      } else if (statusCode >= 400) {
+        this.logger.warn(logMessage)
+      } else {
+        this.logger.log(logMessage)
+      }
+    })
+
+    next()
+  }
+}

--- a/src/schema/logs.schema.ts
+++ b/src/schema/logs.schema.ts
@@ -1,0 +1,42 @@
+import { Schema, Prop, SchemaFactory } from '@nestjs/mongoose'
+import { Document, Types } from 'mongoose'
+
+import type { HttpStatus } from '@nestjs/common'
+import type { Model, ObjectId } from 'mongoose'
+
+@Schema({ versionKey: false })
+export class Log extends Document {
+  @Prop({ type: Types.ObjectId, required: true, unique: true })
+  request_id: ObjectId
+
+  @Prop({ type: String, required: true })
+  level: 'log' | 'warn' | 'error'
+
+  @Prop({ type: String, required: true })
+  error_name: string
+
+  @Prop({ type: String, required: true })
+  method: string
+
+  @Prop({ type: Number, required: true })
+  status_code: HttpStatus
+
+  @Prop({ type: String, required: true })
+  message: string
+
+  @Prop({ type: String, required: true })
+  original_url: string
+
+  @Prop({ type: String, required: true })
+  hostname: string
+
+  @Prop({ type: Object, required: true })
+  headers: Record<string, unknown>
+
+  @Prop({ type: Number, required: true, default: Date.now() })
+  timestamp: number
+}
+
+export const LogSchema = SchemaFactory.createForClass(Log)
+
+export type LogModel = Model<Log>


### PR DESCRIPTION
### 1. status 400이상 호출 정보 db로깅 추가
1. 반영 사항
    - [x] api 호출 시 status가 400이상인 응답에 대해서는 현재 사용중인 DB에 로깅
      - collection은 logs라는 네이밍으로 추가
      - DB에 저장되는 로깅 정보는 에러 클래스 명칭, 요청헤더, 호스트, 에러레벨, 메시지, 호출 메서드, 엔드포인트, 요청 시간 등 값 포함