### PR TITLE
[main] 상세검색 페이지 api 추가

### DIFF
--- a/src/events/events.controller.ts
+++ b/src/events/events.controller.ts
@@ -9,23 +9,40 @@ export class EventsController {
 
   @Get('/list')
   @HttpCode(HttpStatus.OK)
-  getEventList(@Query('limit') limit: string, @Query('offset') offset: string) {
-    const result = this.eventsService.getEventList(limit, offset)
-    return result
-  }
-
-  @Get('/list/:categorySeq')
-  @HttpCode(HttpStatus.OK)
-  getEventListByCategory(
-    @Param('categorySeq') categorySeq: string,
+  getEventList(
     @Query('limit') limit: string,
-    @Query('offset') offset: string
+    @Query('offset') offset: string,
+    @Query('categorySeq') categorySeq?: string
   ) {
-    const result = this.eventsService.getEventsByCategory(categorySeq, limit, offset)
+    const result = this.eventsService.getEventList(limit, offset, categorySeq)
     return result
   }
 
-  @Get('/:eventId')
+  @Get('/list/search')
+  @HttpCode(HttpStatus.OK)
+  getEventListBySearch(
+    @Query('limit') limit: string,
+    @Query('offset') offset: string,
+    @Query('eventName') eventName: string,
+    @Query('startDate') startDate: string,
+    @Query('endDate') endDate: string,
+    @Query('categorySeq') categorySeq?: number,
+    @Query('guSeq') guSeq?: number
+  ) {
+    const result = this.eventsService.getEventListBySearch(
+      limit,
+      offset,
+      eventName,
+      startDate,
+      endDate,
+      categorySeq,
+      guSeq
+    )
+
+    return result
+  }
+
+  @Get('/detail/:eventId')
   @HttpCode(HttpStatus.OK)
   getEventDetail(@Param('eventId') eventId: string) {
     const result = this.eventsService.getEventDetail(eventId)

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -14,15 +14,17 @@ import type { EventsModel, IEventData } from '@/events/types/events.type'
 export class EventsService {
   constructor(@InjectModel(Events.name) private eventsModel: EventsModel) {}
 
-  async getEventList(limit: string, offset: string) {
+  async getEventList(limit: string, offset: string, categorySeq?: string) {
     try {
       if (!limit || !offset) throw new BadRequestException('limit 또는 offset 값이 없습니다.')
       if (Number.isNaN(Number(limit)) || Number.isNaN(Number(offset)))
         throw new BadRequestException('유효하지 않은 limit 혹은 offset 값입니다.')
+      if (categorySeq && Number.isNaN(Number(categorySeq)))
+        throw new BadRequestException('유효하지 않은 카테고리입니다.')
 
       const eventListData: IEventData[] = await this.eventsModel
         .find(
-          {},
+          { ...(categorySeq && { category_seq: categorySeq }) },
           {
             _id: 0,
             event_id: 1,
@@ -39,33 +41,12 @@ export class EventsService {
         .skip(Number(offset))
         .exec()
 
-      const totalData = await this.eventsModel.countDocuments().exec()
-      const resultData = eventListData.map((data) => new EventDTO(data))
-      const result = new EventListResponseDTO(resultData, totalData)
-
-      return result
-    } catch (err) {
-      if (err instanceof HttpException) throw err
-      else throw new InternalServerErrorException(err)
-    }
-  }
-
-  async getEventsByCategory(categorySeq: string, limit: string, offset: string) {
-    try {
-      if (categorySeq == null || Number.isNaN(Number(categorySeq)))
-        throw new BadRequestException('유효하지 않은 카테고리 입니다.')
-      if (!limit || !offset) throw new BadRequestException('limit 또는 offset 값이 없습니다.')
-      if (Number.isNaN(Number(limit)) || Number.isNaN(Number(offset)))
-        throw new BadRequestException('유효하지 않은 limit 혹은 offset 값입니다.')
-
-      const eventsListData: IEventData[] = await this.eventsModel
-        .find({ category_seq: categorySeq })
-        .limit(Number(limit))
-        .skip(Number(offset))
+      const totalDataCount = await this.eventsModel
+        .countDocuments({ ...(categorySeq && { category_seq: Number(categorySeq) }) })
         .exec()
-      const totalData = await this.eventsModel.countDocuments({ category_seq: categorySeq }).exec()
-      const resultData = eventsListData.map((data) => new EventDTO(data))
-      const result = new EventListResponseDTO(resultData, totalData)
+
+      const resultData = eventListData.map((data) => new EventDTO(data))
+      const result = new EventListResponseDTO(resultData, totalDataCount)
 
       return result
     } catch (err) {
@@ -83,6 +64,49 @@ export class EventsService {
 
       const detailData = new EventDTO(eventDetailData)
       const result = new EventDetailResponseDTO(detailData)
+
+      return result
+    } catch (err) {
+      if (err instanceof HttpException) throw err
+      else throw new InternalServerErrorException(err)
+    }
+  }
+
+  async getEventListBySearch(
+    limit: string,
+    offset: string,
+    eventName: string,
+    startDate: string,
+    endDate: string,
+    categorySeq?: number,
+    guSeq?: number
+  ) {
+    try {
+      if (!limit || !offset) throw new BadRequestException('limit 또는 offset 값이 없습니다.')
+      if (Number.isNaN(Number(limit)) || Number.isNaN(Number(offset)))
+        throw new BadRequestException('유효하지 않은 limit 혹은 offset 값입니다.')
+      if (!eventName) throw new BadRequestException('검색어가 없습니다.')
+      if (!startDate || !endDate) throw new BadRequestException('시작일 또는 종료일이 없습니다.')
+      if (categorySeq && Number.isNaN(categorySeq)) throw new BadRequestException('유효하지 않은 카테고리입니다.')
+      if (guSeq && Number.isNaN(guSeq)) throw new BadRequestException('유효하지 않은 지역입니다.')
+
+      const query = {
+        event_name: { $regex: eventName, $options: 'i' },
+        start_date: { $gte: startDate },
+        end_date: { $lte: endDate },
+        ...(categorySeq && { category_seq: categorySeq }),
+        ...(guSeq && { gu_seq: guSeq })
+      }
+
+      const eventListData: IEventData[] = await this.eventsModel
+        .find(query)
+        .limit(Number(limit))
+        .skip(Number(offset))
+        .exec()
+      const totalDataCount = await this.eventsModel.countDocuments(query).exec()
+
+      const resultData = eventListData.map((data) => new EventDTO(data))
+      const result = new EventListResponseDTO(resultData, totalDataCount)
 
       return result
     } catch (err) {

--- a/src/schema/events.schema.ts
+++ b/src/schema/events.schema.ts
@@ -48,17 +48,17 @@ export class Events extends Document {
   @Prop({ type: String, required: true })
   main_img: string
 
-  @Prop({ type: Date, required: true })
-  reg_date: Date
+  @Prop({ type: String, required: true })
+  reg_date: string
 
   @Prop({ type: Boolean, required: true })
   is_public: boolean
 
-  @Prop({ type: Date, required: true })
-  start_date: Date
+  @Prop({ type: String, required: true })
+  start_date: string
 
-  @Prop({ type: Date, required: true })
-  end_date: Date
+  @Prop({ type: String, required: true })
+  end_date: string
 
   @Prop({ type: String, default: null })
   theme: string | null


### PR DESCRIPTION
### 1. 상세검색 페이지 api 추가
1. 반영 사항
    - [x] 상세 검색 페이지내 api 추가 (`/event/list/search`)
      - [api 명세서](https://www.postman.com/iyo-spaceship-766683/workspace/project-may-seoulful/request/20362759-b83e2b49-31b9-4a98-9d43-8dc43b2f2653?action=share&source=copy-link&creator=20362759)
2. 참고 사항
    - 기존 DB에 저장된 데이터 중 reg_date, start_date, end_date는 string형태로 저장되어있었기에 반환 형태로 string으로 동일하게 수정
      - AS-IS: `Date`
      - TO-BE: `String`
    - 작업간 endpoint 충돌로 인해 기존 api endpoint 일부 수정작업 병행
