### PR TITLE
[main] geohash 기반 내 주변 행사 찾기 api 완료

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seoulmate-server",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "",
   "author": "",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node dist/main",
+    "start:prod": "node dist/main.js",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix"
   },
   "dependencies": {

--- a/src/events/events.controller.ts
+++ b/src/events/events.controller.ts
@@ -48,4 +48,11 @@ export class EventsController {
     const result = this.eventsService.getEventDetail(eventId)
     return result
   }
+
+  @Get('/nearby')
+  @HttpCode(HttpStatus.OK)
+  getNearbyEventList(@Query('geohash') geohash: string) {
+    const result = this.eventsService.getNearbyEventList(geohash)
+    return result
+  }
 }

--- a/src/events/events.dto.ts
+++ b/src/events/events.dto.ts
@@ -70,3 +70,10 @@ export class EventDetailResponseDTO {
     this.data = data
   }
 }
+
+export class NearbyEventResponseDTO {
+  data: Record<string, EventDTO[]>
+  constructor(data: Record<string, EventDTO[]>) {
+    this.data = data
+  }
+}

--- a/src/events/events.dto.ts
+++ b/src/events/events.dto.ts
@@ -24,6 +24,7 @@ export class EventDTO {
   longitude: number
   isFree: boolean
   detailUrl: string
+  geohash: string
 
   constructor(data: IEventData) {
     this.eventId = data.event_id
@@ -49,6 +50,7 @@ export class EventDTO {
     this.longitude = data.longitude
     this.isFree = data.is_free
     this.detailUrl = data.detail_url
+    this.geohash = data.geohash
   }
 }
 

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -154,6 +154,8 @@ export class EventsService {
         {} as Record<string, EventDTO[]>
       )
 
+      queryResult.length = 0
+
       const result = new NearbyEventResponseDTO(resultData)
       return result
     } catch (err) {

--- a/src/events/types/events.type.ts
+++ b/src/events/types/events.type.ts
@@ -25,6 +25,7 @@ export interface IEventData {
   longitude: number
   is_free: boolean
   detail_url: string
+  geohash: string
 }
 
 export type EventsModel = Model<IEventData>

--- a/src/schema/events.schema.ts
+++ b/src/schema/events.schema.ts
@@ -74,6 +74,9 @@ export class Events extends Document {
 
   @Prop({ type: String, required: true })
   detail_url: string
+
+  @Prop({ type: String, required: true })
+  geohash: string
 }
 
 export const EventsSchema = SchemaFactory.createForClass(Events)


### PR DESCRIPTION
### 1. geohash 기반 내 주변 행사 찾기 api 완료
1. 반영 사항
    - [x] geohash기반 내 주변 행사 찾기 api 작업: `/event/nearby?geohash`
    - [x] geohash는 6자리 기준으로 쿼리 진행
      - DB에는 8자리로 저장되어있는 상태임
    - [x] geohash 갯수는 최대 9개로 제한
2. 참고 사항
    - 자세한 사항은 [POSTMAN](https://www.postman.com/iyo-spaceship-766683/workspace/project-may-seoulful/request/20362759-f31fdc95-6391-4c44-8195-9f2af4972574?action=share&source=copy-link&creator=20362759)문서 참고