### PR TITLE
[main] 메인페이지 이벤트 검색 목적 기존 api startDate, endDate 옵셔널 처리

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seoulmate-server",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "",
   "author": "",
   "private": true,


### PR DESCRIPTION
### 1. 메인페이지 이벤트 검색 목적 기존 api startDate, endDate 옵셔널 처리
1. 반영 사항
    - [x] /event/list/search api의 query params중 startDate와 endDate를 옵셔널로 처리
      - 메인페이지 내 event_name단독 검색 목적
2. 참고 사항
    - 6.23(일) 회의 간 도출된 내용에 의한 작업
      - 참고 figma 이미지
        ![메인페이지 검색결과](https://github.com/project-may/seoulful-server/assets/97019802/8dec8b5f-57bf-4319-8afd-dfbda9d6eefd)
