### PR TITLE
[main] logger schema 중 hostname default값 부여

### DIFF
--- a/src/schema/logs.schema.ts
+++ b/src/schema/logs.schema.ts
@@ -27,7 +27,7 @@ export class Log extends Document {
   @Prop({ type: String, required: true })
   original_url: string
 
-  @Prop({ type: String, required: true })
+  @Prop({ type: String, required: true, default: 'unknown-host' })
   hostname: string
 
   @Prop({ type: Object, required: true })


### PR DESCRIPTION
### 1. logger schema hostname default값 부여
1. 반영 사항
    - [x] hostname 스키마에 default 'unknown-host'값 지정
      - hostname이 없는 요청이 있을때 required 필드로 인해 서버가 같이 다운되버리는 현상에 의한 디버깅 작업
